### PR TITLE
Restore hover text on quarks/obtanium

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 <td width=120px;><p class="prestigeunlock" id="diamondDisplay" style="color: cyan">1</p></td>
                 <td style="font-size:0;"><img  class="prestigeunlock" src="Pictures/Offering.png" title='Offering'  style="font-size:0;"></td>
                 <td width=120px;><p class="prestigeunlock" id="offeringDisplay"  style="color:gold;">1</p></td>
-                <td style="font-size:0;"><img class="transcendunlock" src="Pictures/Quark.png"></td>
+                <td style="font-size:0;"><img class="transcendunlock" src="Pictures/Quark.png" title='Quark'></td>
                 <td width="120px;"><p class="transcendunlock" id="quarkDisplay" style="color:white">1</p><td>
 
 
@@ -65,7 +65,7 @@
                 <td> <p class="transcendunlock" id="mythosshardDisplay" style="color:plum;">1</p></td>
                 <td style="font-size:0;"> <img class="reincarnationunlock" src="Pictures/Particle.png" title='Particle'  style="font-size:0;"></td>
                 <td> <p class="reincarnationunlock" id="particlesDisplay" style="color:limegreen;">1</p></td>
-                <td style="font-size:0;"><img class="reincarnationunlock" src="Pictures/Obtainium.png"></td>
+                <td style="font-size:0;"><img class="reincarnationunlock" src="Pictures/Obtainium.png" title='Obtanium'></td>
                 <td><p class="reincarnationunlock" id="obtainiumDisplay" style="color:pink">1</p><td>
 
             </tr>


### PR DESCRIPTION
The hovertext was lost when their positions were swapped in a prior update. They're the only two with no hovertext. Trivial, but annoying!