### PR TITLE
Updated displayed Rune 5 multiplier on Obtainium gains to reflect actual multiplier in calculate.js

### DIFF
--- a/Javascript/runes.js
+++ b/Javascript/runes.js
@@ -32,7 +32,7 @@
         }
         if (i == 5) {
             if (updatelevelup) {document.getElementById("runeshowlevelup").textContent = "~(2^(level/300) * (1 + level/150))x Obtainium, 1 + Level^2/1440 Ant Hatch Speed, +0.4 * level seconds of offering timer extension."}
-            document.getElementById("runeshowpower5").childNodes[0].textContent = "S. Intellect Rune Bonus: " + "Obtainium gain x" + format((1 + (1 + rune5level/150 * m * SILevelMult) * Math.pow(2, rune5level * m * SILevelMult/300)),2,true) + ". Ant Speed: x" + format(1 + Math.pow(rune5level * m * SILevelMult, 2)/1440) + ". Offering timer extension: +" + (rune5level * 0.4).toFixed(2) + " seconds."
+            document.getElementById("runeshowpower5").childNodes[0].textContent = "S. Intellect Rune Bonus: " + "Obtainium gain x" + format(((1 + rune5level/150 * m * SILevelMult) * Math.pow(2, rune5level * m * SILevelMult/300)),2,true) + ". Ant Speed: x" + format(1 + Math.pow(rune5level * m * SILevelMult, 2)/1440) + ". Offering timer extension: +" + (rune5level * 0.4).toFixed(2) + " seconds."
 		}
 		if (updatelevelup)document.getElementById("runedisplayexp").textContent = "+" + format(amountPerOffering) + " EXP per offering."
        


### PR DESCRIPTION
As of currently, without this change, the displayed multiplier is `actualMultiplier + 1`.
In other words, a x1.1 multiplier is currently displayed as x2.1, a x5 multiplier is currently displayed as x6, and so on.