### PR TITLE
Resets the text under the offering amount toggle to the original when Ascending

### DIFF
--- a/Javascript/reset.js
+++ b/Javascript/reset.js
@@ -523,7 +523,7 @@ function reset(i,fast) {
         document.getElementById("upg"+j).style.backgroundColor = "black"
         }
     }
-
+    document.getElementById("toggleofferingbuy").innerHTML = "Toggle amount to use per sacrifice"
     }
 
 


### PR DESCRIPTION
Previously, the text from particle upgrade 4x3 used to stay after Ascending until refresh, this fixes that.