### PR TITLE
Replace the time format used in exported save files

### DIFF
--- a/Javascript/exportimport.js
+++ b/Javascript/exportimport.js
@@ -1,11 +1,8 @@
 function getRealTime() {
-let months = [null, 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-let indicator = ['AM','PM']
-let now = new Date();
-let date = (months[now.getMonth()+1])+'-'+ now.getDate()+'-'+now.getFullYear();
-var time = (now.getHours() % 12) + '-' + now.getMinutes() + '-' + now.getSeconds() + ' ' + indicator[Math.floor(now.getHours()/12)];
-
-return(date+' '+time)
+    let now = new Date();
+    let date = `${now.getFullYear()}-${now.getMonth()+1}-${now.getDate()}`
+    let time = now.toLocaleTimeString();
+    return date + " " + time;
 }
 
 function exportSynergism() {


### PR DESCRIPTION
 ... with ISO date format (year-month-day) and locale-specific time format to facilitate better sorting of the files and accommodating people in other parts of the world