### PR TITLE
Make reset info more stable and readable

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -159,6 +159,7 @@ a {color: white;}
 	width: 500px;
 	text-align: center;
 	font-size: 15px;
+	font-variant-numeric: tabular-nums;
 }
 #resetrewards {
 	position: absolute;


### PR DESCRIPTION
Makes the numbers in reset info block monospace using `tabular-nums` to prevent the text jumping around rapidly from text overflow due to differently sized digits. Massively improves readability in situations like challenges.