### PR TITLE
Clean up achievement awarding, set nomultiplier to false when needed

### DIFF
--- a/Javascript/achievements.js
+++ b/Javascript/achievements.js
@@ -381,12 +381,6 @@ function resetachievementcheck(i) {
         if (player.transcendnocoinorprestigeupgrades == true) {
             achievementaward(66)
         }
-        if (player.transcendnoaccelerator == true) {
-            achievementaward(61)
-        }
-        if (player.transcendnomultiplier == true) {
-            achievementaward(58)
-        }
         if (transcendPointGain.greaterThanOrEqualTo(1)) {
             achievementaward(43)
         }

--- a/Javascript/buystuff.js
+++ b/Javascript/buystuff.js
@@ -179,6 +179,10 @@ function buyMultiplier(autobuyer){
 		thisCost = getCostMultiplier(buyFrom);
 		player.multiplierCost = thisCost;
 	}
+
+	player.prestigenomultiplier = false;
+	player.transcendnomultiplier = false;
+	player.reincarnatenomultiplier = false;
     updateAllMultiplier();
     if (player.multiplierBought >= 2 && player.achievements[155] == 0){achievementaward(155)}
     if (player.multiplierBought >= 20 && player.achievements[156] == 0){achievementaward(156)}


### PR DESCRIPTION
This commit stops some achievements from being awarded twice in the same function based on the same conditions (58 and 61), and sets the nomultiplier variables to false when you buy a multiplier. This PR is for the v1011 branch because that was the default branch when I forked; I can make a PR for master if that'd be preferable.