### PR TITLE
Normalize exponent after getCost()

### DIFF
--- a/Javascript/buystuff.js
+++ b/Javascript/buystuff.js
@@ -333,7 +333,6 @@ function buyMax(pos, type, num, originalCost, autobuyer = false) {
     // go down by 7 steps below the last one able to be bought and spend the cost of 25 up to the one that you started with and stop if coin goes below requirement
     let buyFrom = Math.max(buyStart + buyInc - 7, player[pos + 'Owned' + type] + 1);
     let thisCost = getCost(originalCost, buyFrom, type, num, r);
-    console.log(thisCost);
     while (buyFrom < buyStart + buyInc && player[tag].greaterThanOrEqualTo(thisCost)) {
         player[tag] = player[tag].sub(thisCost);
         player[pos + 'Owned' + type] = buyFrom;

--- a/Javascript/buystuff.js
+++ b/Javascript/buystuff.js
@@ -287,6 +287,10 @@ function getCost(originalCost, buyingTo, type, num, r) {
         // divided by same amount buying to - fr times
         cost.exponent -= Math.log10(1 + (1 / 2 * player.challengecompletions[8])) * (buyingTo - fr);
     }
+    let extra = cost.exponent - Math.floor(cost.exponent);
+    cost.exponent = Math.floor(cost.exponent);
+    cost.mantissa *= Math.pow(10, extra);
+    cost.normalize();
     return cost;
 }
 
@@ -329,6 +333,7 @@ function buyMax(pos, type, num, originalCost, autobuyer = false) {
     // go down by 7 steps below the last one able to be bought and spend the cost of 25 up to the one that you started with and stop if coin goes below requirement
     let buyFrom = Math.max(buyStart + buyInc - 7, player[pos + 'Owned' + type] + 1);
     let thisCost = getCost(originalCost, buyFrom, type, num, r);
+    console.log(thisCost);
     while (buyFrom < buyStart + buyInc && player[tag].greaterThanOrEqualTo(thisCost)) {
         player[tag] = player[tag].sub(thisCost);
         player[pos + 'Owned' + type] = buyFrom;


### PR DESCRIPTION
Fixes a bug related to non-integer exponents on a decimal causing undefined behavior with producers.