### PR TITLE
feat: antsac triggers cube autorune first

### DIFF
--- a/Javascript/ants.js
+++ b/Javascript/ants.js
@@ -371,6 +371,21 @@ function sacrificeAnts(auto) {
                 player.legendaryFragments += sacRewards.legendaryFragments;
                 player.mythicalFragments += sacRewards.mythicalFragments;
             }
+
+            // Refer to analogous code in Syngergism.js, function tick().
+            if (player.shopUpgrades.offeringAutoLevel > 0.5 && player.autoSacrificeToggle) {
+                // Since ants boost rune EXP, we need to auto-spend offerings NOW, before reset, if cube-tier auto-spend is enabled.
+                if (player.cubeUpgrades[20] === 1 && player.runeshards >= 5) {
+                    let baseAmount = Math.floor(player.runeshards / 5);
+                    for (let i = 1; i <= 5; i++) {
+                        redeemShards(i, true, baseAmount);
+                    }
+                    player.sacrificeTimer = 0;
+                }
+                // Other cases don't perform a spend-all and are thus safely handled by the standard tick() function.
+            }
+
+            // Now we're safe to reset the ants.
             resetAnts();
             player.antSacrificeTimer = 0;
             updateTalismanInventory();


### PR DESCRIPTION
Written by referring to https://github.com/Pseudonian/SynergismOfficial/blob/501f74b875c7641464e56b60ec5ebea41ac910c6/Synergism.js#L2920-L2936.

By using similar code during the ant-sacrifice process, we can spend all incoming "rune shards" (offerings) before the rune EXP multiplier from ant upgrades disappears.

-----

For comparison, I ran the same test twice - once 'before' and once 'after', both with 120 second ant-sacrifices.  No cube expenditures or anything; the runs should be near identical.  ("Near", because auto-challenge timings are never perfect.)  I made sure to screenshot the second my temporary output code indicated that an ant-sac had occurred.

Before:

![image](https://user-images.githubusercontent.com/31546028/93870549-924f1780-fcf7-11ea-9737-ea8b5a95ed34.png)

After:

![image](https://user-images.githubusercontent.com/31546028/93870577-9da24300-fcf7-11ea-9ade-b4ad8627629c.png)

In case it helps with verification, I did a third run simply to capture the actual ant-multiplier as closely as possible:

![image](https://user-images.githubusercontent.com/31546028/93870633-b3b00380-fcf7-11ea-8c52-0506e01dd8ae.png)
