### PR TITLE
Reverted the resetrewards table to have 288px offset from the start of the reset buttons

### DIFF
--- a/Javascript/reset.js
+++ b/Javascript/reset.js
@@ -364,7 +364,9 @@ function reset(i, fast, from) {
         player.reincarnationCount += 1;
 
         player.transcendPoints = new Decimal("0");
-        player.reincarnationPoints = player.reincarnationPoints.add(reincarnationPointGain);
+        if (player.currentChallenge.reincarnation === 0) {
+            player.reincarnationPoints = player.reincarnationPoints.add(reincarnationPointGain);
+        }
         player.reincarnationShards = new Decimal("0");
         player.challengecompletions[1] = 0;
         player.challengecompletions[2] = 0;

--- a/Synergism.css
+++ b/Synergism.css
@@ -164,7 +164,7 @@ a {color: white;}
 #resetrewards {
 	position: absolute;
 	top: -10px;
-	left: 260px;
+	left: 288px;
 }
 
 #tabrow {


### PR DESCRIPTION
To fixes the offerings overlapping the ascension button
![kuva](https://user-images.githubusercontent.com/20047400/94320176-fe9a7700-ff94-11ea-8b10-89ead7a2e530.png)
after fix
![kuva](https://user-images.githubusercontent.com/20047400/94320134-e0347b80-ff94-11ea-8790-be5f61413abe.png)
 
Also disabled particle gain from reincarnating during R challenges