### PR TITLE
Force number formatting to be in English-US

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -1269,6 +1269,7 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
     player.dayTimer = (60 * 60 * 24 - (s + 60 * m + 60 * 60 * h))
 }
 
+const numberFormatter = new Intl.NumberFormat('en-US');
 /**
  * This function displays the numbers such as 1,234 or 1.00e1234 or 1.00e1.234M.
  * @param {Decimal | number} input number/Decimal to be formatted
@@ -1325,7 +1326,7 @@ function format(input, accuracy = 0, long = false) {
         const [front, back] = standardString.split('.');
         // Apply a number group 3 comma regex to the front
         const frontFormatted = 'BigInt' in window 
-            ? BigInt(front).toLocaleString()
+            ? numberFormatter.format(BigInt(front))
             : front.replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // if the back is undefined that means there are no decimals to display, return just the front
         if (back === undefined) {
@@ -1340,7 +1341,7 @@ function format(input, accuracy = 0, long = false) {
         const mantissaLook = (Math.floor(mantissa * 100) / 100).toFixed(2);
         // Makes the power group 3 with commas
         const powerLook = 'BigInt' in window 
-            ? BigInt(power).toLocaleString()
+            ? numberFormatter.format(BigInt(power))
             : power.toString().replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // returns format (1.23e456,789)
         return mantissaLook + "e" + powerLook;


### PR DESCRIPTION
PR #161 ended up breaking the display for people with certain non-English locales, as it now uses the thousands separator from the user's locale but always uses a dot for the decimal. For example, in German, "1.001" and "1001" now both display formatted as "1.001".

See commit message for too much text explaining why it's fixed this way instead of using the users locale.