### PR TITLE
Revert & redo "Force number formatting to be in English-US"

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -1345,7 +1345,7 @@ function format(input, accuracy = 0, long = false) {
         const [front, back] = standardString.split('.');
         // Apply a number group 3 comma regex to the front
         const frontFormatted = 'BigInt' in window 
-            ? BigInt(front).toLocaleString()
+            ? BigInt(front).toLocaleString('en-US')
             : front.replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // if the back is undefined that means there are no decimals to display, return just the front
         if (back === undefined) {
@@ -1360,7 +1360,7 @@ function format(input, accuracy = 0, long = false) {
         const mantissaLook = (Math.floor(mantissa * 100) / 100).toFixed(2);
         // Makes the power group 3 with commas
         const powerLook = 'BigInt' in window 
-            ? BigInt(power).toLocaleString()
+            ? BigInt(power).toLocaleString('en-US')
             : power.toString().replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // returns format (1.23e456,789)
         return mantissaLook + "e" + powerLook;

--- a/Synergism.js
+++ b/Synergism.js
@@ -1289,7 +1289,6 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
     player.dayTimer = (60 * 60 * 24 - (s + 60 * m + 60 * 60 * h))
 }
 
-const numberFormatter = new Intl.NumberFormat('en-US');
 /**
  * This function displays the numbers such as 1,234 or 1.00e1234 or 1.00e1.234M.
  * @param {Decimal | number} input number/Decimal to be formatted
@@ -1346,7 +1345,7 @@ function format(input, accuracy = 0, long = false) {
         const [front, back] = standardString.split('.');
         // Apply a number group 3 comma regex to the front
         const frontFormatted = 'BigInt' in window 
-            ? numberFormatter.format(BigInt(front))
+            ? BigInt(front).toLocaleString()
             : front.replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // if the back is undefined that means there are no decimals to display, return just the front
         if (back === undefined) {
@@ -1361,7 +1360,7 @@ function format(input, accuracy = 0, long = false) {
         const mantissaLook = (Math.floor(mantissa * 100) / 100).toFixed(2);
         // Makes the power group 3 with commas
         const powerLook = 'BigInt' in window 
-            ? numberFormatter.format(BigInt(power))
+            ? BigInt(power).toLocaleString()
             : power.toString().replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // returns format (1.23e456,789)
         return mantissaLook + "e" + powerLook;


### PR DESCRIPTION
This reverts commit 6f23bce9d5f208e151b429957311e300ca443608 and PR #166 and then fixes it again.

Apparently there's a set of Chrome versions that supports BigInt but can't handle formatting them well, breaking the whole formatting function and the game's load. The broken versions are currently believed to be linked to the [locales entry on the MDN table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString#Browser_compatibility), so Chrome 67-75 (pre-July 2019) and maybe Firefox 68-69 (pre-Oct 2019). There doesn't seem to be any documentation of this on the internet.

Fixed in a slightly slower way now (which is ignored on those versions instead of broken), shouldn't be slower than how it used to be. Fix tested in Chromium 67 and current versions of Chrome/Firefox.