### PR TITLE
Fixed the ability to purchase maxed upgrades.

### DIFF
--- a/Javascript/cubes.js
+++ b/Javascript/cubes.js
@@ -241,7 +241,7 @@ function updateCubeUpgradeBG(i) {
 function buyCubeUpgrades(i,linGrowth) {
     linGrowth = linGrowth || 0;
     let metaData = getCubeCost(i,linGrowth);
-    if(player.wowCubes >= metaData[1] && player.cubeUpgrades[i] <= cubeMaxLevel[i]){
+    if(player.wowCubes >= metaData[1] && player.cubeUpgrades[i] < cubeMaxLevel[i]){
     player.wowCubes -= 100 / 100 * metaData[1];
     player.cubeUpgrades[i] = metaData[0];
     }


### PR DESCRIPTION
Change '<=' to '<' since having '<=' would make buying a max upgrade legal.