### PR TITLE
Fix importing pre-v2 savegames with the smaller researches array

### DIFF
--- a/Javascript/checkvariables.js
+++ b/Javascript/checkvariables.js
@@ -182,17 +182,20 @@ function checkVariablesOnLoad(data) {
     }
     if (data.loadedOct4Hotfix === undefined || player.loadedOct4Hotfix === false) {
         player.loadedOct4Hotfix = true;
-        player.researchPoints += player.researches[200] * 1e56;
-        player.researches[200] = 0;
-        buyResearch(200, true, 0.01);
-        console.log('Refunded 8x25, and gave you ' + format(player.researches[200]) + ' levels of new cost 8x25. Sorry!')
-        player.researchPoints += player.researches[195] * 1e60;
-        player.worlds += 250 * player.researches[195]
-        player.researches[195] = 0;
-        console.log('Refunded 8x20 and gave 250 quarks for each level you had prior to loading up the game.')
-        player.wowCubes += player.cubeUpgrades[50] * 5e10
-        player.cubeUpgrades[50] = 0
-        console.log('Refunded w5x10. Enjoy!')
+        // Only process refund if the save's researches array is already updated to v2
+        if (player.researches.length > 200) {
+            player.researchPoints += player.researches[200] * 1e56;
+            player.researches[200] = 0;
+            buyResearch(200, true, 0.01);
+            console.log('Refunded 8x25, and gave you ' + format(player.researches[200]) + ' levels of new cost 8x25. Sorry!')
+            player.researchPoints += player.researches[195] * 1e60;
+            player.worlds += 250 * player.researches[195]
+            player.researches[195] = 0;
+            console.log('Refunded 8x20 and gave 250 quarks for each level you had prior to loading up the game.')
+            player.wowCubes += player.cubeUpgrades[50] * 5e10
+            player.cubeUpgrades[50] = 0
+            console.log('Refunded w5x10. Enjoy!')
+        }
     }
 
     if (player.ascStatToggles === undefined || data.ascStatToggles === undefined) {


### PR DESCRIPTION
Some people reported that importing a v1.011 or older save gave them undefined/NaN quarks & obtainium, breaking the game.

Cause seems to be that the refund process for the old 8x20 and 8x25 researches tries to multiply by something that isn't added yet. The refund process runs before the save updates run. I tested this fix on a save provided by an user on Discord as well as my old v1 & v2.0.0-2.0.4 saves.

There's nothing to refund for old saves so this just skips the refund process and marks it as done.