### PR TITLE
Fix the bug Wolvzrain encountered

### DIFF
--- a/Javascript/checkvariables.js
+++ b/Javascript/checkvariables.js
@@ -198,8 +198,16 @@ function checkVariablesOnLoad(data) {
         }
     }
 
-    if (player.ascStatToggles === undefined || data.ascStatToggles === undefined) {
+    if (player.ascStatToggles === undefined) {
         player.ascStatToggles = {
+            1: false,
+            2: false,
+            3: false,
+            4: false
+        };
+    }
+    if (data.ascStatToggles === undefined) {
+        data.ascStatToggles = {
             1: false,
             2: false,
             3: false,


### PR DESCRIPTION
Idk about the things that lead up to this state, but if `data.ascStatToggles` is `undefined`, the use of the `||` on the new line 217 means we try to reference something on `undefined` leading to a crash. There are other ways to fix this issue, like a second null check or using a negated, DeMorgan's-d check (`!(player.ascStatToggles[4] !== undefined && data.ascStatToggles[4] !== undefined)`) to avoid trying to reference a property of `undefined`. I took the just initialize `data.ascStatToggles` approach, but I have no context. I think you might also want to set `data.ascStatToggles[4]` in the if branch, too?