### PR TITLE
Disable text selection

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -19,6 +19,9 @@ body {
 	margin: 0;
 	box-sizing: border-box;
 }
+main {
+    user-select: none;
+}
 btn {
 	color: #171717
 }


### PR DESCRIPTION
This is to keep stray double- or triple-clicks from selecting text. This prevents the resulting text highlighting from cluttering up the visual field.
