### PR TITLE
Use Intl.NumberFormat for format(), again

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -1321,6 +1321,24 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
     player.dayTimer = (60 * 60 * 24 - (s + 60 * m + 60 * 60 * h))
 }
 
+let numberFormatter = false;
+if (window.BigInt && window.Intl && window.Intl.NumberFormat) {
+    // Check if there's BigInt support + a browser that can sanely format BigInts (some versions of Chrome/Firefox can't).
+    try {
+        numberFormatter = new Intl.NumberFormat("en-US");
+        if (!numberFormatter || numberFormatter.format(BigInt(1234)) !== "1,234") {
+            numberFormatter = false;
+        }
+    } catch (e) {
+        // Browser can't do it, leave numberFormatter set to false to fall back to regex code
+        numberFormatter = false;
+        console.log("Using slower number formatting code: browser failed self-test");
+    }
+}
+else {
+    console.log("Using slower number formatting code: browser doesn't support necessary features");
+}
+
 /**
  * This function displays the numbers such as 1,234 or 1.00e1234 or 1.00e1.234M.
  * @param {Decimal | number} input number/Decimal to be formatted
@@ -1376,8 +1394,8 @@ function format(input, accuracy = 0, long = false) {
         // Split it on the decimal place
         const [front, back] = standardString.split('.');
         // Apply a number group 3 comma regex to the front
-        const frontFormatted = 'BigInt' in window
-            ? BigInt(front).toLocaleString('en-US')
+        const frontFormatted = numberFormatter
+            ? numberFormatter.format(BigInt(front))
             : front.replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // if the back is undefined that means there are no decimals to display, return just the front
         if (back === undefined) {
@@ -1391,8 +1409,8 @@ function format(input, accuracy = 0, long = false) {
         // Makes mantissa be rounded down to 2 decimal places
         const mantissaLook = (Math.floor(mantissa * 100) / 100).toFixed(2);
         // Makes the power group 3 with commas
-        const powerLook = 'BigInt' in window
-            ? BigInt(power).toLocaleString('en-US')
+        const powerLook = numberFormatter
+            ? numberFormatter.format(BigInt(power))
             : power.toString().replace(/(\d)(?=(\d{3})+$)/g, "$1,");
         // returns format (1.23e456,789)
         return mantissaLook + "e" + powerLook;


### PR DESCRIPTION
Some benchmarking has shown that this results in a significant speedup
compared to the current method, and format() is a heavy
bottleneck of the whole game.

Speedups vary based on test sets. In practical testing I'm seeing
a speedup of about 20-30x on format() and ~20-30% overall with PR #213.
Without that PR, the gains are even bigger, as even more format() calls
are present and called on nearly every tick.

Unlike the original PR, this includes feature detection/selftest that
will silently fall back to the old regex code that's used for browsers
without BigInt support.

Tested in Firefox 82, Chromium 89 and Chromium 67.

See https://discord.com/channels/677271830838640680/751464752835854386/776949504162922506 for more info on performance, and see PR #166 and #180 for previous entries in the formatting trilogy saga.