### PR TITLE
Use long formatting for per second displays in ascend history

### DIFF
--- a/Javascript/history.js
+++ b/Javascript/history.js
@@ -100,7 +100,7 @@ function conditionalFormatPerSecond(numOrStr, data) {
         if (numOrStr === 0) { // work around format(0, 3) return 0 instead of 0.000, for consistency
             return "0.000/s";
         }
-        return format(numOrStr / ((data.seconds && data.seconds > 0) ? data.seconds : 1), 3) + "/s";
+        return format(numOrStr / ((data.seconds && data.seconds > 0) ? data.seconds : 1), 3, true) + "/s";
     }
     return format(numOrStr);
 }


### PR DESCRIPTION
Requested on Discord, per-second numbers between 0-1000 will now display with 3 digits instead of none, instead of stopping abruptly at 10.

The default cutoff worked fine for cubes/tess/hyper which go boom around 10 but platcubes scale much slower than that.