### PR TITLE
Hackfix for undefined obtainium when buying 100% talisman resources

### DIFF
--- a/Javascript/talismans.js
+++ b/Javascript/talismans.js
@@ -116,6 +116,20 @@ function buyTalismanResources(type, percentage) {
 
         player.researchPoints -= talismanResourcesData.obtainiumCost;
         player.runeshards -= talismanResourcesData.offeringCost;
+
+        // When dealing with high values, calculations can be very slightly off due to floating point precision
+        // and result in buying slightly (usually 1) more than the player can actually afford.
+        // This results in negative obtainium or offerings with further calcs somehow resulting in NaN/undefined.
+        // Instead of trying to work around floating point limits, just make sure nothing breaks as a result.
+        // The calculation being done overall is similar to the following calculation:
+        // 2.9992198253874083e47 - (Math.floor(2.9992198253874083e47 / 1e20) * 1e20)
+        // which, for most values, returns 0, but values like this example will return a negative number instead.
+        if (player.researchPoints < 0) {
+            player.researchPoints = 0;
+        }
+        if (player.runeshards < 0) {
+            player.runeshards = 0;
+        }
     }
     updateTalismanCostDisplay(type, percentage)
     updateTalismanInventory()


### PR DESCRIPTION
Turns out it was floating point precision. `2.9992198253874083e47 - (Math.floor(2.9992198253874083e47 / 1e20) * 1e20)` should be 0 but for some numbers, it isn't (even without the floor).

When the player's obtainium is negative enough (-1 doesn't do the trick), it turns into NaN a tick later. So if it turns negative, this just sets it to 0. It's never off by more than a few resources and it's not like 1 extra resource matters when you're buying e16 or more.

This also fixes the negative offerings, which can happen if the player's max buy count is limited by offerings instead of obt, for more or less the same reason.