### PR TITLE
Improved tesseract building autobuyer

### DIFF
--- a/Javascript/reset.js
+++ b/Javascript/reset.js
@@ -177,12 +177,12 @@ function updateAutoReset(i) {
 }
 
 function updateTesseractAutoBuyAmount() {
-    let v = parseFloat(document.getElementById("tesseractamount").value);
+    let v = parseFloat(document.getElementById("tesseractAmount").value);
         v = Math.floor(v)
         if (v >= 0) {
-            player.autotesseractbuyamount = v
+            player.tesseractAutoBuyerAmount = v
         } else {
-            player.autotesseractbuyamount = 0;
+            player.tesseractAutoBuyerAmount = 0;
         }
 }
 

--- a/Javascript/reset.js
+++ b/Javascript/reset.js
@@ -176,6 +176,15 @@ function updateAutoReset(i) {
     }
 }
 
+function updateTesseractAutoBuyAmount() {
+    let v = parseFloat(document.getElementById("tesseractamount").value);
+        v = Math.floor(v)
+        if (v >= 0) {
+            player.autotesseractbuyamount = v
+        } else {
+            player.autotesseractbuyamount = 0;
+        }
+}
 
 function reset(i, fast, from) {
     fast = fast || false

--- a/Javascript/toggles.js
+++ b/Javascript/toggles.js
@@ -337,13 +337,13 @@ function toggleautoreset(i) {
 }
 
 function toggleautobuytesseract() {
-    if (player.tesseractautobuyer === 1 || player.tesseractautobuyer === 0) {
-        player.tesseractautobuyer = 2;
+    if (player.tesseractAutoBuyerToggle === 1 || player.tesseractAutoBuyerToggle === 0) {
+        player.tesseractAutoBuyerToggle = 2;
         document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: OFF"
         document.getElementById("tesseractautobuytoggle").style.border = "2px solid red"
         
     } else {
-        player.tesseractautobuyer = 1;
+        player.tesseractAutoBuyerToggle = 1;
         document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: ON"
         document.getElementById("tesseractautobuytoggle").style.border = "2px solid green"
         }

--- a/Javascript/toggles.js
+++ b/Javascript/toggles.js
@@ -336,6 +336,19 @@ function toggleautoreset(i) {
     }
 }
 
+function toggleautobuytesseract() {
+    if (player.tesseractautobuyer === 1 || player.tesseractautobuyer === 0) {
+        player.tesseractautobuyer = 2;
+        document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: OFF"
+        document.getElementById("tesseractautobuytoggle").style.border = "2px solid red"
+        
+    } else {
+        player.tesseractautobuyer = 1;
+        document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: ON"
+        document.getElementById("tesseractautobuytoggle").style.border = "2px solid green"
+        }
+}
+
 function toggleauto() {
     const autos = document.getElementsByClassName("auto");
     for (const auto of autos) {

--- a/Javascript/updateVisuals.js
+++ b/Javascript/updateVisuals.js
@@ -148,7 +148,7 @@ function visualUpdateBuildings() {
 
         document.getElementById("tesseractInfo").textContent = "You have " + format(player.wowTesseracts) + " Wow! Tesseracts. Gain more by beating Challenge 10 on each Ascension."
         document.getElementById("ascendShardInfo").textContent = "You have a mathematical constant of " + format(player.ascendShards, 2) + ". Taxes are divided by " + format(Math.pow(Decimal.log(player.ascendShards.add(1), 10) + 1, 1 + .2 / 60 * player.challengecompletions[10] * player.upgrades[125] + 0.1 * player.platonicUpgrades[5] + 0.2 * player.platonicUpgrades[10] + 0.5 * player.platonicUpgrades[15] + (platonicBonusMultiplier[5] - 1)), 4, true) + "."
-        document.getElementById("autotessbuyeramount").textContent = "Auto buyer will save at least " + format(player.autotesseractbuyamount) + " tesseracts. [Enter number above]."
+        document.getElementById("autotessbuyeramount").textContent = "Auto buyer will save at least " + format(player.tesseractAutoBuyerAmount) + " tesseracts. [Enter number above]."
     }
 }
 

--- a/Javascript/updateVisuals.js
+++ b/Javascript/updateVisuals.js
@@ -148,6 +148,7 @@ function visualUpdateBuildings() {
 
         document.getElementById("tesseractInfo").textContent = "You have " + format(player.wowTesseracts) + " Wow! Tesseracts. Gain more by beating Challenge 10 on each Ascension."
         document.getElementById("ascendShardInfo").textContent = "You have a mathematical constant of " + format(player.ascendShards, 2) + ". Taxes are divided by " + format(Math.pow(Decimal.log(player.ascendShards.add(1), 10) + 1, 1 + .2 / 60 * player.challengecompletions[10] * player.upgrades[125] + 0.1 * player.platonicUpgrades[5] + 0.2 * player.platonicUpgrades[10] + 0.5 * player.platonicUpgrades[15] + (platonicBonusMultiplier[5] - 1)), 4, true) + "."
+        document.getElementById("autotessbuyeramount").textContent = "Auto buyer will save at least " + format(player.autotesseractbuyamount) + " tesseracts. [Enter number above]."
     }
 }
 

--- a/Synergism.css
+++ b/Synergism.css
@@ -4509,10 +4509,54 @@ margin-left: -13px
 	left: 50%;
 	margin-left: -180px;
 }
+
+#tesseractautobuytoggle {
+	position:absolute;
+	width: 150px;
+	top: 440px;
+	left: 50%;
+	margin-left: -75px;
+}
+
+#autotesseract {
+	position: absolute;
+	top: 500px;
+	padding: 0;
+	left: 50%;
+	width: 750px;
+	margin-left: -375px;
+	text-align: center;
+	color: white
+}
+
+#tesseractamount {
+	position: absolute;
+	top: 465px;
+	padding: 0;
+	left: 50%;
+	width: 100px;
+	margin-left: -50px;
+	border: 1px solid green;
+	color: white;
+	background-color: black
+}
+
+#autotessbuyeramount{
+	position: absolute;
+	padding: 5px;
+	top: 465px;
+	left: 50%;
+	width: 1200px;
+	margin-left: -600px;
+	height: 20px;
+	color: white;
+	text-align: center;
+}
+
 #ascendHotKeys{
 	position: absolute;
 	padding: 5px;
-	top: 460px;
+	top: 500px;
 	left: 50%;
 	width: 1200px;
 	margin-left: -600px;

--- a/Synergism.css
+++ b/Synergism.css
@@ -4510,7 +4510,7 @@ margin-left: -13px
 	margin-left: -180px;
 }
 
-#tesseractautobuytoggle {
+#tesseractautobuytoggle{
 	position:absolute;
 	width: 150px;
 	top: 440px;
@@ -4518,18 +4518,7 @@ margin-left: -13px
 	margin-left: -75px;
 }
 
-#autotesseract {
-	position: absolute;
-	top: 500px;
-	padding: 0;
-	left: 50%;
-	width: 750px;
-	margin-left: -375px;
-	text-align: center;
-	color: white
-}
-
-#tesseractamount {
+#tesseractamount{
 	position: absolute;
 	top: 465px;
 	padding: 0;

--- a/Synergism.css
+++ b/Synergism.css
@@ -4518,7 +4518,7 @@ margin-left: -13px
 	margin-left: -75px;
 }
 
-#tesseractamount{
+#tesseractAmount{
 	position: absolute;
 	top: 465px;
 	padding: 0;

--- a/Synergism.js
+++ b/Synergism.js
@@ -361,7 +361,7 @@ const player = {
     resettoggle2: 1,
     resettoggle3: 1,
 
-    tesseractautobuyer: 0,
+    tesseractautobuyertoggle: 0,
     autotesseractbuyamount: 0,
 
     coinbuyamount: 1,
@@ -974,8 +974,8 @@ function loadSynergy() {
             player.resettoggle2 = 1;
             player.resettoggle3 = 1;
         }
-        if (player.tesseractautobuyer === 0) {
-            player.tesseractautobuyer = 1;
+        if (player.tesseractautobuyertoggle === 0) {
+            player.tesseractautobuyertoggle = 1;
         }
         if (player.reincarnationCount < 0.5 && player.unlocks.rrow4 === true) {
             player.unlocks = {
@@ -1236,11 +1236,11 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
             document.getElementById("reincarnateautotoggle").textContent = "Mode: TIME"
         }
 
-        if (player.tesseractautobuyer === 1) {
+        if (player.tesseractautobuyertoggle === 1) {
             document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: ON"
             document.getElementById("tesseractautobuytoggle").style.border = "2px solid green"
         }
-        if (player.tesseractautobuyer === 2) {
+        if (player.tesseractautobuyertoggle === 2) {
             document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: OFF"
             document.getElementById("tesseractautobuytoggle").style.border = "2px solid red"
         }
@@ -2718,7 +2718,7 @@ function updateAll() {
     }
 
 //Loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
-    if ((player.researches[190] > 0) && (player.tesseractautobuyer == 1)) {
+    if ((player.researches[190] > 0) && (player.tesseractautobuyertoggle == 1)) {
         cheapestTesseractBuilding =  {cost:0, intCost:0, index:0, intCostArray:[1,10,100,1000,10000]}
         for (let i = 0; i < cheapestTesseractBuilding.intCostArray.length; i++){
             if ((player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) + player.autotesseractbuyamount) && player.autoTesseracts[i+1]) {

--- a/Synergism.js
+++ b/Synergism.js
@@ -361,6 +361,9 @@ const player = {
     resettoggle2: 1,
     resettoggle3: 1,
 
+    tesseractautobuyer: 0,
+    autotesseractbuyamount: 0,
+
     coinbuyamount: 1,
     crystalbuyamount: 1,
     mythosbuyamount: 1,
@@ -971,6 +974,9 @@ function loadSynergy() {
             player.resettoggle2 = 1;
             player.resettoggle3 = 1;
         }
+        if (player.tesseractautobuyer === 0) {
+            player.tesseractautobuyer = 1;
+        }
         if (player.reincarnationCount < 0.5 && player.unlocks.rrow4 === true) {
             player.unlocks = {
                 coinone: false,
@@ -1230,6 +1236,14 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
             document.getElementById("reincarnateautotoggle").textContent = "Mode: TIME"
         }
 
+        if (player.tesseractautobuyer === 1) {
+            document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: ON"
+            document.getElementById("tesseractautobuytoggle").style.border = "2px solid green"
+        }
+        if (player.tesseractautobuyer === 2) {
+            document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: OFF"
+            document.getElementById("tesseractautobuytoggle").style.border = "2px solid red"
+        }
 
         if (player.autoResearchToggle) {
             document.getElementById("toggleautoresearch").textContent = "Automatic: ON"
@@ -2703,11 +2717,11 @@ function updateAll() {
         }
     }
 
-//Now loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
-    if (player.researches[190] > 0) {
+//Loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
+    if ((player.researches[190] > 0) && (player.tesseractautobuyer == 1)) {
         cheapestTesseractBuilding =  {cost:0, intCost:0, index:0, intCostArray:[1,10,100,1000,10000]}
         for (let i = 0; i < cheapestTesseractBuilding.intCostArray.length; i++){
-            if (player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) && player.autoTesseracts[i+1]) {
+            if ((player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) + player.autotesseractbuyamount) && player.autoTesseracts[i+1]) {
                 if ((getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1] < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
                     cheapestTesseractBuilding.cost = getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1];
                     cheapestTesseractBuilding.intCost=cheapestTesseractBuilding.intCostArray[i];

--- a/Synergism.js
+++ b/Synergism.js
@@ -361,8 +361,8 @@ const player = {
     resettoggle2: 1,
     resettoggle3: 1,
 
-    tesseractautobuyertoggle: 0,
-    autotesseractbuyamount: 0,
+    tesseractAutoBuyerToggle: 0,
+    tesseractAutoBuyerAmount: 0,
 
     coinbuyamount: 1,
     crystalbuyamount: 1,
@@ -974,8 +974,8 @@ function loadSynergy() {
             player.resettoggle2 = 1;
             player.resettoggle3 = 1;
         }
-        if (player.tesseractautobuyertoggle === 0) {
-            player.tesseractautobuyertoggle = 1;
+        if (player.tesseractAutoBuyerToggle === 0) {
+            player.tesseractAutoBuyerToggle = 1;
         }
         if (player.reincarnationCount < 0.5 && player.unlocks.rrow4 === true) {
             player.unlocks = {
@@ -1236,11 +1236,11 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
             document.getElementById("reincarnateautotoggle").textContent = "Mode: TIME"
         }
 
-        if (player.tesseractautobuyertoggle === 1) {
+        if (player.tesseractAutoBuyerToggle === 1) {
             document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: ON"
             document.getElementById("tesseractautobuytoggle").style.border = "2px solid green"
         }
-        if (player.tesseractautobuyertoggle === 2) {
+        if (player.tesseractAutoBuyerToggle === 2) {
             document.getElementById("tesseractautobuytoggle").textContent = "Auto Buy: OFF"
             document.getElementById("tesseractautobuytoggle").style.border = "2px solid red"
         }
@@ -2718,10 +2718,10 @@ function updateAll() {
     }
 
 //Loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
-    if ((player.researches[190] > 0) && (player.tesseractautobuyertoggle == 1)) {
+    if ((player.researches[190] > 0) && (player.tesseractAutoBuyerToggle == 1)) {
         cheapestTesseractBuilding =  {cost:0, intCost:0, index:0, intCostArray:[1,10,100,1000,10000]}
         for (let i = 0; i < cheapestTesseractBuilding.intCostArray.length; i++){
-            if ((player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) + player.autotesseractbuyamount) && player.autoTesseracts[i+1]) {
+            if ((player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) + player.tesseractAutoBuyerAmount) && player.autoTesseracts[i+1]) {
                 if ((getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1] < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
                     cheapestTesseractBuilding.cost = getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1];
                     cheapestTesseractBuilding.intCost=cheapestTesseractBuilding.intCostArray[i];

--- a/Synergism.js
+++ b/Synergism.js
@@ -2703,21 +2703,20 @@ function updateAll() {
         }
     }
 
+//Now loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
     if (player.researches[190] > 0) {
-        if (player.wowTesseracts >= 10000 * Math.pow(1 + player.ascendBuilding5.owned, 3) && player.autoTesseracts[5]) {
-            buyTesseractBuilding(10000, 5)
+        cheapestTesseractBuilding =  {cost:0, intCost:0, index:0, intCostArray:[1,10,100,1000,10000]}
+        for (let i = 0; i < cheapestTesseractBuilding.intCostArray.length; i++){
+            if (player.wowTesseracts >= cheapestTesseractBuilding.intCostArray[i] * Math.pow(1 + player['ascendBuilding' + (i+1)]['owned'], 3) && player.autoTesseracts[i+1]) {
+                if ((getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1] < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
+                    cheapestTesseractBuilding.cost = getTesseractCost([cheapestTesseractBuilding.intCostArray[i]], [i+1])[1];
+                    cheapestTesseractBuilding.intCost=cheapestTesseractBuilding.intCostArray[i];
+                    cheapestTesseractBuilding.index=[i+1];
+                }
+            }
         }
-        if (player.wowTesseracts >= 1000 * Math.pow(1 + player.ascendBuilding4.owned, 3) && player.autoTesseracts[4]) {
-            buyTesseractBuilding(1000, 4)
-        }
-        if (player.wowTesseracts >= 100 * Math.pow(1 + player.ascendBuilding3.owned, 3) && player.autoTesseracts[3]) {
-            buyTesseractBuilding(100, 3)
-        }
-        if (player.wowTesseracts >= 10 * Math.pow(1 + player.ascendBuilding2.owned, 3) && player.autoTesseracts[2]) {
-            buyTesseractBuilding(10, 2)
-        }
-        if (player.wowTesseracts >= 1 * Math.pow(1 + player.ascendBuilding1.owned, 3) && player.autoTesseracts[1]) {
-            buyTesseractBuilding(1, 1)
+        if (cheapestTesseractBuilding.index > 0){
+            buyTesseractBuilding(cheapestTesseractBuilding.intCost, cheapestTesseractBuilding.index);     
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@
         </div>
         <div id="ascendautomation">
             <button id="tesseractautobuytoggle" onclick="toggleautobuytesseract()" style="border:2px solid red; background-color: #171717;">Auto Buy: OFF</button>
-        <input class="tesseractautobuyamount" type="number" id="tesseractamount" min="1" max="999999999" defaultValue="1" oninput="updateTesseractAutoBuyAmount()">
+        <input class="tesseractautobuyamount" type="number" id="tesseractAmount" min="1" max="999999999" defaultValue="1" oninput="updateTesseractAutoBuyAmount()">
         <p class="tesseractautobuyamount" id="autotessbuyeramount"></p>
         </div>
         <p id="ascendHotKeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer.</p>

--- a/index.html
+++ b/index.html
@@ -503,8 +503,8 @@
         </div>
         <div id="ascendautomation">
             <button id="tesseractautobuytoggle" onclick="toggleautobuytesseract()" style="border:2px solid red; background-color: #171717;">Auto Buy: OFF</button>
-        <input class="tesseractunlock" type="number" id="tesseractamount" min="1" max="999999999" defaultValue="1" oninput="updateTesseractAutoBuyAmount()">
-        <p class="tesseractunlock" id="autotessbuyeramount"></p>
+        <input class="tesseractautobuyamount" type="number" id="tesseractamount" min="1" max="999999999" defaultValue="1" oninput="updateTesseractAutoBuyAmount()">
+        <p class="tesseractautobuyamount" id="autotessbuyeramount"></p>
         </div>
         <p id="ascendHotKeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer.</p>
     </div>

--- a/index.html
+++ b/index.html
@@ -501,6 +501,11 @@
             <p id="constUpgradeCost" style="color: white">Cost: <span id="constUpgradeCost2" style="color: orchid">---</span> from your Constant</p>
             <p id="constUpgradeEffect1" style="color: white">Current Effect: <span id="constUpgradeEffect2" style="color: orchid">---</span></p>
         </div>
+        <div id="ascendautomation">
+            <button id="tesseractautobuytoggle" onclick="toggleautobuytesseract()" style="border:2px solid red; background-color: #171717;">Auto Buy: OFF</button>
+        <input class="tesseractunlock" type="number" id="tesseractamount" min="1" max="999999999" defaultValue="1" oninput="updateTesseractAutoBuyAmount()">
+        <p class="tesseractunlock" id="autotessbuyeramount"></p>
+        </div>
         <p id="ascendHotKeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer.</p>
     </div>
 </div>


### PR DESCRIPTION
This is my attempt at improving the tesseract autobuyer so it behaves in a way that better fits player expectations.  

Apologies in advance, I never really touch JavaScript and haven't used git in ages so If something is screwed up or I did something wrong in this PR process let me know, any/all other feedback certainly appreciated also (@KittensGiveMorboGas on the discord if you need me to change something).  Hopefully this is something you find useful.

- Autobuyer now loops through buildings and only buys the cheapest one (that has autobuy enabled)
- Added a master toggle to turn on/off autobuy completely (this lets players turn autobuyers on/off without the game immediately spending tess on only 1-2 types of buildings)
- Added an input where players can select an amount of tess to save, this way if a player is saving for plat upgrades etc they can only spend a certain amount via the autobuyer.