### PR TITLE
Proposal to run tick() in a more stable way (less `dt`variation)

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -2908,20 +2908,20 @@ let lastUpdate = 0;
 //gameInterval = 0;
 
 function createTimer() {
-    lastUpdate = Date.now();
-    interval(tick, 5);
+    requestAnimationFrame(tick);
 }
 
 
-function tick() {
+function tick(timestamp) {
+    requestAnimationFrame(tick)
+    let delta = timestamp - lastUpdate
+    lastUpdate = timestamp;
 
     if (!timeWarp) {
-        let now = Date.now();
-        let dt = Math.max(0, Math.min(36000, (now - lastUpdate) / 1000));
+        let dt = Math.max(0, Math.min(36000, (delta) / 1000));
 
         dailyResetCheck();
         let timeMult = calculateTimeAcceleration();
-        lastUpdate = now;
 
         player.quarkstimer += dt
         if (player.quarkstimer >= (90000 + 45000 * player.researches[195])) {


### PR DESCRIPTION
Below comment is a test to use `requestAnimationFrame` to run `tick()`, because of raf throttling, it would completely pause out-of-focus tabs which is a no-go. See 2nd comment for a better proposition to reliably run `tick` with a fixed number of `dt` ms: https://github.com/Pseudonian/SynergismOfficial/pull/233#issuecomment-742778916
<hr>
Currently `tick()` is asked to run every 5ms by `interval(tick, 5)`, meaning
`tick()` was observed being called from 3 to 5+ times during each frame.
A small refactoring allows the use of `requestAnimationFrame` which
ensures that `tick` runs only once per frame.

My initial tests seem to show that such a change does not impact game mechanics but further testing should be done considering how game strats can rely on subtle differences in the code. I'm not ignorantly asking to merge this directly but I'd like to open a discussion about the use of `setInterval` vs. `requestAnimationFrame`. Seems to me that raf is better suited when continuously calling the `tick` function but not knowing why `setInterval` was preferred in the first place, I'm open to discuss the matter.

Observed behaviour with `interval(tick, 5)`:
![Capture d’écran de 2020-12-10 16-16-41](https://user-images.githubusercontent.com/542233/101793431-14d0c180-3b06-11eb-9134-26809702126f.png)

Observed behaviour when using `requestAnimationFrame(tick)`:
![Capture d’écran de 2020-12-10 16-16-45](https://user-images.githubusercontent.com/542233/101793522-2e720900-3b06-11eb-93c5-07237a42b680.png)

Thanks for your work!