### PR TITLE
Improved tick() to a more stable way (less `dt`variation)

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -2904,24 +2904,47 @@ function constantIntervals() {
 }
 
 let lastUpdate = 0;
+let lastLog = 0
 
 //gameInterval = 0;
 
 function createTimer() {
-    lastUpdate = Date.now();
+    lastUpdate = performance.now();
+    lastLog = performance.now();
     interval(tick, 5);
 }
 
+const deltas = [];
+let dt = 5 / 1000;
+let ticks = 0;
+let dtMean = 0;
 
 function tick() {
+    let now = performance.now();
+    let delta = now - lastUpdate;
+    let n = 0;
+    lag1 = now - lastUpdate;
+    while (delta > 5) {
+      let compensation = n > 5 ? n - 5 : 0;
+      tack(dt + compensation / 1000);
+      deltas.push(dt * 1000 + compensation);
+      lastUpdate += 5 + compensation;
+      delta -= 5 + compensation;
+      n += 1;
+      dtMean = (dtMean * ticks + dt * 1000 + compensation) / (ticks + 1);
+      ticks +=1;
+    }
+    if ((now - lastLog) > 1000) {
+      console.log({n, lag1, lag2: now - lastUpdate, dtMean});
+      lastLog = now;
+    }
+}
+
+function tack(dt) {
 
     if (!timeWarp) {
-        let now = Date.now();
-        let dt = Math.max(0, Math.min(36000, (now - lastUpdate) / 1000));
-
         dailyResetCheck();
         let timeMult = calculateTimeAcceleration();
-        lastUpdate = now;
 
         player.quarkstimer += dt
         if (player.quarkstimer >= (90000 + 45000 * player.researches[195])) {

--- a/Synergism.js
+++ b/Synergism.js
@@ -2904,39 +2904,27 @@ function constantIntervals() {
 }
 
 let lastUpdate = 0;
-let lastLog = 0
 
 //gameInterval = 0;
 
 function createTimer() {
     lastUpdate = performance.now();
-    lastLog = performance.now();
     interval(tick, 5);
 }
 
-const deltas = [];
 let dt = 5 / 1000;
-let ticks = 0;
-let dtMean = 0;
 
 function tick() {
     let now = performance.now();
     let delta = now - lastUpdate;
     let n = 0;
-    lag1 = now - lastUpdate;
+    let compensation = 0;
     while (delta > 5) {
-      let compensation = n > 5 ? n - 5 : 0;
+      compensation = n > 5 ? n - 5 : 0;
       tack(dt + compensation / 1000);
-      deltas.push(dt * 1000 + compensation);
       lastUpdate += 5 + compensation;
       delta -= 5 + compensation;
       n += 1;
-      dtMean = (dtMean * ticks + dt * 1000 + compensation) / (ticks + 1);
-      ticks +=1;
-    }
-    if ((now - lastLog) > 1000) {
-      console.log({n, lag1, lag2: now - lastUpdate, dtMean});
-      lastLog = now;
     }
 }
 

--- a/Synergism.js
+++ b/Synergism.js
@@ -2912,19 +2912,25 @@ function createTimer() {
     interval(tick, 5);
 }
 
-let dt = 5 / 1000;
+let dt = 5;
 
 function tick() {
     let now = performance.now();
     let delta = now - lastUpdate;
     let n = 0;
-    let compensation = 0;
+    let dtEffective;
     while (delta > 5) {
-      compensation = n > 5 ? n - 5 : 0;
-      tack(dt + compensation / 1000);
-      lastUpdate += 5 + compensation;
-      delta -= 5 + compensation;
-      n += 1;
+        // tack will compute dtEffective milliseconds of game time
+        dtEffective = dt;
+        // If we're lagging more than a whole frame (16ms) behind, compensate by computing delta - dt ms, up to 1 hour
+        dtEffective += delta > 16 ? Math.min(3600 * 1000, delta - dt) : 0;
+        // If tack is called more than 5 times in one tick, start increasing dtEffective
+        dtEffective += n > 5 ? n - 5 : 0;
+        // run tack and record timings
+        tack(dtEffective / 1000);
+        lastUpdate += dtEffective;
+        delta -= dtEffective;
+        n += 1;
     }
 }
 


### PR DESCRIPTION
Following the discussion on https://github.com/Pseudonian/SynergismOfficial/pull/233 here's an improved version of `tick`.

`tick` continues to be called by the `setInterval` of 5ms but instead of directly computing `now - lastUpdated` ms of game time, it will make several computations of 5ms of game time until the delta between now and lastUpdated is resolved.

This method accounts for occasional increased lag (or just slow computers) by increasing the base `dt` of 5ms accordingly.