### PR TITLE
Update Synergism.css

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -320,6 +320,7 @@ a {color: white;}
 	border: 1px solid orange;
 	left: 72%;
 	margin-left: -50px;
+	z-index: 2;
 }
 
 .buildingTabs {


### PR DESCRIPTION
In some situations, the traits tab becomes mostly unclickable.  Using z-index:2 fixes this issue.

For example, this issue happens if all of the following is true:
• User is on Chrome
• Browser zoom is set to 100%
• User is on Kong version (i.e., not github.io )
• User is on Corruption Tab
• User is on Corruption Loadouts Sub-Tab