### PR TITLE
Bugfix: challenge levels display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1352,15 +1352,15 @@
                     <td ><div class="challengeLevels" id="challenge4level">0 / 25</div></td>
                     <td ><div class="challengeLevels" id="challenge5level">0 / 25</div></td>
                     <td ><div class="challengeLevels" id="challenge6level">0 / 25</div></td>
-                    <td ><div class="challengeLevels" id="challenge7level" class="chal6">0 / 25</div></td>
-                    <td ><div class="challengeLevels" id="challenge8level" class="chal7">0 / 25</div></td>
-                    <td ><div class="challengeLevels" id="challenge9level" class="chal8">0 / 25</div></td>
-                    <td ><div class="challengeLevels" id="challenge10level" class="chal9">0 / 25</div></td>
-                    <td ><div class="challengeLevels" id="challenge11level" class="ascendunlock">0 / 10</div></td>
-                    <td ><div class="challengeLevels" id="challenge12level" class="chal11">0 / 10</div></td>
-                    <td ><div class="challengeLevels" id="challenge13level" class="chal12">0 / 10</div></td>
-                    <td ><div class="challengeLevels" id="challenge14level" class="chal13">0 / 10</div></td>
-                    <td ><div class="challengeLevels" id="challenge15level" class="chal14">0 / 9001</div></td>
+                    <td ><div class="challengeLevels chal6" id="challenge7level">0 / 25</div></td>
+                    <td ><div class="challengeLevels chal7" id="challenge8level">0 / 25</div></td>
+                    <td ><div class="challengeLevels chal8" id="challenge9level">0 / 25</div></td>
+                    <td ><div class="challengeLevels chal9" id="challenge10level">0 / 25</div></td>
+                    <td ><div class="challengeLevels ascendunlock" id="challenge11level">0 / 10</div></td>
+                    <td ><div class="challengeLevels chal11" id="challenge12level">0 / 10</div></td>
+                    <td ><div class="challengeLevels chal12" id="challenge13level">0 / 10</div></td>
+                    <td ><div class="challengeLevels chal13" id="challenge14level">0 / 10</div></td>
+                    <td ><div class="challengeLevels chal14" id="challenge15level">0 / 9001</div></td>
                 </tr>
                 </table>
             </div>


### PR DESCRIPTION
Bug reports: challenge levels were displayed for locked challenges.
![Capture d’écran de 2020-12-17 07-21-22_bug](https://user-images.githubusercontent.com/542233/102451384-a6758d00-4038-11eb-8265-d728d949cba9.png)
Fix: only one class attribute is allowed per html element.
![Capture d’écran de 2020-12-17 07-21-22](https://user-images.githubusercontent.com/542233/102451405-b1c8b880-4038-11eb-9d15-08fdb6dc47d8.png)

