### PR TITLE
Fix UI issue where ant sacrifice mode could be displayed incorrectly …

### DIFF
--- a/Synergism.js
+++ b/Synergism.js
@@ -1268,10 +1268,10 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
         }
 
         for (let i = 1; i <= 2; i++) {
-            toggleAntMaxBuy()
-            toggleAntAutoSacrifice()
+            toggleAntMaxBuy();
+            toggleAntAutoSacrifice(0);
+            toggleAntAutoSacrifice(1);
         }
-
 
         document.getElementById("historyTogglePerSecondButton").textContent = "Per second: " + (player.historyShowPerSecond ? "ON" : "OFF");
         document.getElementById("historyTogglePerSecondButton").style.borderColor = (player.historyShowPerSecond ? "green" : "red");
@@ -1279,12 +1279,6 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
         if (!player.autoAscend) {
             document.getElementById("ascensionAutoEnable").textContent = "Auto Ascend [OFF]";
             document.getElementById("ascensionAutoEnable").style.border = "2px solid red"
-        }
-
-
-        for (let i = 1; i <= 2; i++) {
-            toggleAntMaxBuy()
-            toggleAntAutoSacrifice()
         }
 
         player.autoResearch = Math.min(200, player.autoResearch)


### PR DESCRIPTION
…on load.

You could see the issue if you had your ant sacrifice set to "Real-Time", saved, closed the browser... then reloaded the save.

Prior to the change, it would only set the Auto Sacrifice On/Off button to the saved value.  Now it correctly sets both to the saved values.

Tested locally, seems to work as intended...

Also removed a second call to the same for-loop as I couldn't determine any reason for it to be called a second time and seemed like a bad code merge at some point.

Cheers!