### PR TITLE
Toggles for talisman Auto Fortify/Enhance and change to quark shop reset

### DIFF
--- a/Javascript/shop.js
+++ b/Javascript/shop.js
@@ -2,10 +2,10 @@ const offerconsumedesc = "Instantly gain 2 real life hours of Offerings, based o
 const obtainiumconsumedesc = "Instantly gain 2 real life hours of Obtainium, based on your all time best Obtainium/sec and speed acceleration!"
 
 const offertimerdesc = "Gain +(level)^2 /4% more offerings from all sources!"
-const offerautodesc = "Automatically pour Offerings into a rune. 1st level unlocks feature, and each level increases Offering gain by 2%. Every second, 2^(Level) levels worth of offerings are spent. TO ACTIVATE: Click on the rune icon (PICTURE) and it will turn orange just for you!"
+const offerautodesc = "Automatically pour Offerings into a rune. 1st level unlocks feature, and each level increases Offering gain by 2%. Every second, 2^(Level) levels worth of offerings are spent. [First Level Cannot be refunded!]"
 const obtainiumtimerdesc = "Gain +(level)^2 /2% more obtainium from all sources!"
-const obtainiumautodesc = "Automatically pour Obtainium into a research. 1st level unlocks feature, and each level increases Obtainium gain by 2%. Every reincarnation, dump all Obtainium into research until maxed."
-const instantchallengedesc = "T and R challenges don't cause resets if retry is enabled and gain up to 10 completions per tick. Addtionally, instantly gain T challenge completions up to highest completed when exiting R challenges."
+const obtainiumautodesc = "Automatically pour Obtainium into a research. 1st level unlocks feature, and each level increases Obtainium gain by 2%. Every reincarnation, dump all Obtainium into research until maxed. [First Level Cannot be Refunded!]"
+const instantchallengedesc = "T and R challenges don't cause resets if retry is enabled and gain up to 10 completions per tick. Addtionally, instantly gain T challenge completions up to highest completed when exiting R challenges. [Cannot be Refunded!]"
 const cashgrabdesc = "This is a cash grab but it gives a couple cool stats. +1% production per level to Offerings and Obtainium."
 const antspeeddesc = "Each level gives a 1.5x speed multiplier to all Ant tiers' production! Short and simple."
 const shoptalismandesc = "Permanently unlock a Shop talisman! [Warning: you can't refund this and this is VERY expensive to level. Be sure you want to buy it!]"
@@ -251,21 +251,17 @@ function resetShopUpgrades() {
                 player.shopUpgrades.offeringTimerLevel -= 1;
                 player.worlds += (150 + 25 * i)
             }
-            if (player.shopUpgrades.offeringAutoLevel > 0) {
+            if (player.shopUpgrades.offeringAutoLevel > 1) {
                 player.shopUpgrades.offeringAutoLevel -= 1;
-                player.worlds += (150 + 25 * i)
+                player.worlds += (175 + 25 * i)
             }
             if (player.shopUpgrades.obtainiumTimerLevel > 0) {
                 player.shopUpgrades.obtainiumTimerLevel -= 1;
                 player.worlds += (150 + 25 * i)
             }
-            if (player.shopUpgrades.obtainiumAutoLevel > 0) {
+            if (player.shopUpgrades.obtainiumAutoLevel > 1) {
                 player.shopUpgrades.obtainiumAutoLevel -= 1;
-                player.worlds += (150 + 25 * i)
-            }
-            if (player.shopUpgrades.instantChallengeBought) {
-                player.shopUpgrades.instantChallengeBought = false;
-                player.worlds += (300)
+                player.worlds += (175 + 25 * i)
             }
             if (player.shopUpgrades.antSpeedLevel > 0) {
                 player.shopUpgrades.antSpeedLevel -= 1;

--- a/Javascript/shop.js
+++ b/Javascript/shop.js
@@ -280,18 +280,6 @@ function resetShopUpgrades() {
                 player.worlds += (500 + 250 * i)
             }
         }
-
-        if (player.autoResearch > 0.5) {
-            document.getElementById("res" + player.autoResearch).style.backgroundColor = "black"
-        }
-        if (player.autoSacrifice > 0.5) {
-            document.getElementById("rune" + player.autoSacrifice).style.backgroundColor = "black"
-        }
-        player.autoSacrificeToggle = false;
-        player.autoResearchToggle = false;
-        player.autoResearch = 0;
-        player.autoSacrifice = 0;
-        player.sacrificeTimer = 0;
         revealStuff();
     }
 }

--- a/Javascript/toggles.js
+++ b/Javascript/toggles.js
@@ -422,11 +422,13 @@ function toggleAutoSacrifice(index) {
     if (index === 0) {
         if (player.autoSacrificeToggle) {
             player.autoSacrificeToggle = false;
-            el.textContent = "Automatic: OFF";
+            el.textContent = "Auto Runes: OFF";
+            document.getElementById("toggleautosacrifice").style.border = "2px solid red"
             player.autoSacrifice = 0;
         } else {
             player.autoSacrificeToggle = true;
-            el.textContent = "Automatic: ON"
+            el.textContent = "Auto Runes: ON"
+            document.getElementById("toggleautosacrifice").style.border = "2px solid green"
         }
     } else if (player.autoSacrificeToggle && player.shopUpgrades.offeringAutoLevel > 0.5) {
         player.autoSacrifice = index;
@@ -504,6 +506,30 @@ function toggleRuneScreen(index) {
         }
     }
     player.subtabNumber = index - 1
+}
+
+function toggleautofortify() {
+    if (player.autoFortifyToggle === false && player.researches[130] == 1) {
+        player.autoFortifyToggle = true;
+        document.getElementById("toggleautofortify").textContent = "Auto Fortify: ON"
+        document.getElementById("toggleautofortify").style.border = "2px solid green"        
+    } else {
+        player.autoFortifyToggle = false;
+        document.getElementById("toggleautofortify").textContent = "Auto Fortify: OFF"
+        document.getElementById("toggleautofortify").style.border = "2px solid red"
+        }
+}
+
+function toggleautoenhance() {
+    if (player.autoEnhanceToggle === false && player.researches[135] == 1) {
+        player.autoEnhanceToggle = true;
+        document.getElementById("toggleautoenhance").textContent = "Auto Enhance: ON"
+        document.getElementById("toggleautoenhance").style.border = "2px solid green"        
+    } else {
+        player.autoEnhanceToggle = false;
+        document.getElementById("toggleautoenhance").textContent = "Auto Enhance: OFF"
+        document.getElementById("toggleautoenhance").style.border = "2px solid red"
+        }
 }
 
 function setActiveSettingScreen(subtab, clickedButton) {

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -232,6 +232,15 @@ function revealStuff() {
             document.getElementById("tesseractAutoToggle" + z).style.display = "block" :
             document.getElementById("tesseractAutoToggle" + z).style.display = "none";
     }
+    player.researches[190] > 0 ? //8x15 Research [Auto Tesseracts]
+        document.getElementById("tesseractautobuytoggle").style.display = "block" :
+        document.getElementById("tesseractautobuytoggle").style.display = "none";
+    player.researches[190] > 0 ? //8x15 Research [Auto Tesseracts]
+        document.getElementById("tesseractAmount").style.display = "block" :
+        document.getElementById("tesseractAmount").style.display = "none";
+    player.researches[190] > 0 ? //8x15 Research [Auto Tesseracts]
+        document.getElementById("autotessbuyeramount").style.display = "block" :
+        document.getElementById("autotessbuyeramount").style.display = "none";
     (player.antUpgrades[12] > 0 || player.ascensionCount > 0) ? //Ant Talisman Unlock, Mortuus
         document.getElementById("talisman6area").style.display = "block" :
         document.getElementById("talisman6area").style.display = "none";

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -219,9 +219,13 @@ function revealStuff() {
         document.getElementById("rune5area").style.display = "block" :
         document.getElementById("rune5area").style.display = "none";
 
-    player.researches[124] > 0 ? //5x24 Research [AutoSac]
-        document.getElementById("antSacrificeButtons").style.display = "block" :
-        document.getElementById("antSacrificeButtons").style.display = "none";
+    player.researches[130] > 0 ? //6x5 Research [Talisman Auto Fortify]
+        document.getElementById("toggleautofortify").style.display = "block" :
+        document.getElementById("toggleautofortify").style.display = "none";
+
+    player.researches[135] > 0 ? //6x10 Research [Talisman Auto Sac]
+        document.getElementById("toggleautoenhance").style.display = "block" :
+        document.getElementById("toggleautoenhance").style.display = "none";
 
     for (let z = 1; z <= 5; z++) {
         (player.researches[190] > 0) ? //8x15 Research [Auto Tesseracts]

--- a/Synergism.css
+++ b/Synergism.css
@@ -1918,8 +1918,8 @@ margin-left: -13px
 	padding: 5px;
 	top: 10px;
 	left: 38%;
-	width: 100px;
-	margin-left: -100px;
+	width: 120px;
+	margin-left: -120px;
 	height: 30px;
 	text-align: center;
 }
@@ -2348,7 +2348,22 @@ margin-left: -13px
 	color: gray;
 	text-align: center;
 }
-
+#toggleautofortify {
+	position: absolute;
+	top: 65px;
+	margin-left: 10px;
+	width: 125px;
+	height: 30px;
+	text-align: center;
+}
+#toggleautoenhance {
+	position: absolute;
+	top: 100px;
+	margin-left: 10px;
+	width: 125px;
+	height: 30px;
+	text-align: center;
+}
 #talismancounter {
 	position: absolute;
 	top: 45px;

--- a/Synergism.js
+++ b/Synergism.js
@@ -412,6 +412,8 @@ const player = {
         hypercubeToQuarkBought: false
     },
     autoSacrificeToggle: false,
+    autoFortifyToggle: false,
+    autoEnhanceToggle: false,
     autoResearchToggle: false,
     autoResearch: 0,
     autoSacrifice: 0,
@@ -732,6 +734,8 @@ function loadSynergy() {
             player.autoResearchToggle = false;
             player.autoResearch = 0;
             player.autoSacrifice = 0;
+            player.autoEnhanceToggle = false
+            player.autoFortifyToggle = false
             player.sacrificeTimer = 0;
             player.loaded1009 = true;
             player.codes.set(18, false);
@@ -1255,13 +1259,30 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
         if (!player.autoResearchToggle) {
             document.getElementById("toggleautoresearch").textContent = "Automatic: OFF"
         }
-        if (player.autoSacrificeToggle) {
-            document.getElementById("toggleautosacrifice").textContent = "Automatic: ON"
+        if (player.autoSacrificeToggle == true) {
+            document.getElementById("toggleautosacrifice").textContent = "Auto Rune: ON"
+            document.getElementById("toggleautosacrifice").style.border = "2px solid green"
         }
-        if (!player.autoSacrificeToggle) {
-            document.getElementById("toggleautosacrifice").textContent = "Automatic: OFF"
+        if (player.autoSacrificeToggle == false) {
+            document.getElementById("toggleautosacrifice").textContent = "Auto Rune: OFF"
+            document.getElementById("toggleautosacrifice").style.border = "2px solid red"
         }
-
+        if (player.autoFortifyToggle == true) {
+            document.getElementById("toggleautofortify").textContent = "Auto Fortify: ON"
+            document.getElementById("toggleautofortify").style.border = "2px solid green"
+        }
+        if (player.autoFortifyToggle == false) {
+            document.getElementById("toggleautofortify").textContent = "Auto Fortify: OFF"
+            document.getElementById("toggleautofortify").style.border = "2px solid red"
+        }
+        if (player.autoEnhanceToggle == true) {
+            document.getElementById("toggleautoenhance").textContent = "Auto Enhance: ON"
+            document.getElementById("toggleautoenhance").style.border = "2px solid green"
+        }
+        if (player.autoEnhanceToggle == false) {
+            document.getElementById("toggleautoenhance").textContent = "Auto Enhance: OFF"
+            document.getElementById("toggleautoenhance").style.border = "2px solid red"
+        }
         if (!player.autoAscend) {
             document.getElementById("ascensionAutoEnable").textContent = "Auto Ascend [OFF]";
             document.getElementById("ascensionAutoEnable").style.border = "2px solid red"
@@ -3034,54 +3055,50 @@ function tack(dt) {
         }
 
         if (player.researches[130] > 0 || player.researches[135] > 0) {
-            autoTalismanTimer += dt
-            if (autoTalismanTimer >= 2) {
-                autoTalismanTimer = autoTalismanTimer % 2;
-                if (player.researches[135] > 0) {
-                    if (player.achievements[119] > 0) {
-                        buyTalismanEnhance(1, true)
-                    }
-                    if (player.achievements[126] > 0) {
-                        buyTalismanEnhance(2, true)
-                    }
-                    if (player.achievements[133] > 0) {
-                        buyTalismanEnhance(3, true)
-                    }
-                    if (player.achievements[140] > 0) {
-                        buyTalismanEnhance(4, true)
-                    }
-                    if (player.achievements[147] > 0) {
-                        buyTalismanEnhance(5, true)
-                    }
-                    if (player.antUpgrades[12] > 0 || player.ascensionCount > 0) {
-                        buyTalismanEnhance(6, true)
-                    }
-                    if (player.shopUpgrades.talismanBought) {
-                        buyTalismanEnhance(7, true)
-                    }
+            if (player.researches[135] > 0 && player.autoEnhanceToggle == true) {
+                if (player.achievements[119] > 0) {
+                    buyTalismanEnhance(1, true)
                 }
-                if (player.researches[130] > 0) {
-                    if (player.achievements[119] > 0) {
-                        buyTalismanLevels(1, true)
-                    }
-                    if (player.achievements[126] > 0) {
-                        buyTalismanLevels(2, true)
-                    }
-                    if (player.achievements[133] > 0) {
-                        buyTalismanLevels(3, true)
-                    }
-                    if (player.achievements[140] > 0) {
-                        buyTalismanLevels(4, true)
-                    }
-                    if (player.achievements[147] > 0) {
-                        buyTalismanLevels(5, true)
-                    }
-                    if (player.antUpgrades[12] > 0 || player.ascensionCount > 0) {
-                        buyTalismanLevels(6, true)
-                    }
-                    if (player.shopUpgrades.talismanBought) {
-                        buyTalismanLevels(7, true)
-                    }
+                if (player.achievements[126] > 0) {
+                    buyTalismanEnhance(2, true)
+                }
+                if (player.achievements[133] > 0) {
+                    buyTalismanEnhance(3, true)
+                }
+                if (player.achievements[140] > 0) {
+                    buyTalismanEnhance(4, true)
+                }
+                if (player.achievements[147] > 0) {
+                    buyTalismanEnhance(5, true)
+                }
+                if (player.antUpgrades[12] > 0 || player.ascensionCount > 0) {
+                    buyTalismanEnhance(6, true)
+                }
+                if (player.shopUpgrades.talismanBought) {
+                    buyTalismanEnhance(7, true)
+                }
+            }
+            if (player.researches[130] > 0 && player.autoFortifyToggle == true) {
+                if (player.achievements[119] > 0) {
+                    buyTalismanLevels(1, true)
+                }
+                if (player.achievements[126] > 0) {
+                    buyTalismanLevels(2, true)
+                }
+                if (player.achievements[133] > 0) {
+                    buyTalismanLevels(3, true)
+                }
+                if (player.achievements[140] > 0) {
+                    buyTalismanLevels(4, true)
+                }
+                if (player.achievements[147] > 0) {
+                    buyTalismanLevels(5, true)
+                }
+                if (player.antUpgrades[12] > 0 || player.ascensionCount > 0) {
+                    buyTalismanLevels(6, true)
+                }
+                if (player.shopUpgrades.talismanBought) {
+                    buyTalismanLevels(7, true)
                 }
             }
         }

--- a/Synergism.js
+++ b/Synergism.js
@@ -734,8 +734,6 @@ function loadSynergy() {
             player.autoResearchToggle = false;
             player.autoResearch = 0;
             player.autoSacrifice = 0;
-            player.autoEnhanceToggle = false
-            player.autoFortifyToggle = false
             player.sacrificeTimer = 0;
             player.loaded1009 = true;
             player.codes.set(18, false);

--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,7 @@
 
 
         <div id="runes">
+            <button id="toggleautosacrifice" style="border: 2px solid orangered; color: white" onclick="toggleAutoSacrifice(0)">Auto Rune: OFF</button>
             <button id="toggleRuneSubTab1" style="border: 2px solid grey; color: white" onclick="toggleSubTab(4, 0)">Runes</button>
             <button class="chal9" id="toggleRuneSubTab2" style="border: 2px solid grey; color: white" onclick="toggleSubTab(4, 1)">Talismans</button>
             <button class="chal9" id="toggleRuneSubTab3" style="border: 2px solid grey; color: white" onclick="toggleSubTab(4, 2)">Blessings</button>
@@ -1053,9 +1054,6 @@
                 <p id="toggleofferingbuy">Toggle the number of levels to buy per sacrifice</p>
             </div>
             <p id="runeshards">You have 0 Offerings.</p>
-
-            <button id="toggleautosacrifice" style="border: 2px solid orangered; color: yellow" onclick="toggleAutoSacrifice(0)">Automatic: OFF</button>
-
             <div id="rune1area">
             <p id="speedrune" style="color: cyan">Speed Rune</p>
             <img id="rune1" src="Pictures/Transparent Pics/SpeedRune.png" onmouseover="displayRuneInformation(1)" onclick="toggleAutoSacrifice(1)" alt="">
@@ -1125,6 +1123,8 @@
                         <td><img id="talismanHundred" src="Pictures/Transparent Pics/TalismanHundred.png"  style="cursor:pointer;" onclick="toggleTalismanBuy(100)" alt=""></td>
                     </tr>
                 </table>
+                <button id="toggleautoenhance" style="border: 2px solid red; color: white" onclick="toggleautoenhance()">Auto Enhance: OFF</button>
+                <button id="toggleautofortify" style="border: 2px solid red; color: white" onclick="toggleautofortify()">Auto Enhance: OFF</button>
                 <p id="toggletalismanbuy">Toggle percent resources used</p>
                 </div>
                 <table id="talismancounter" style="table-layout: fixed;">


### PR DESCRIPTION
- Added on/off toggles for talisman Enhance/Fortify as in some edge cases users didn't want these to be enabled all the time
     - I removed the timer that made the auto-enhance and auto-fortify slow, since users can turn them off entirely this no longer seemed necessary.  I can't see how this would cause other impacts but if it will I can put the timer back.
- Adjusted rune autobuyer toggle to show on all sub tabs of the main rune tab (changed the text and added red/green background to clarify/show toggle status)
- Adjusted shop respec to leave auto challenge and 1 level each of Auto-Offerings and Auto-Obtanium.  There are almost no situations where players don't want these 3 purchases and it has been requested frequently to make shop resets less trouble.

If there are any issues or questions just let me know here or I am @KittensGiveMorboGas#4170 on discord 



