### PR TITLE
Reintroduce check for autosac display in revealStuff()

### DIFF
--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -219,6 +219,10 @@ function revealStuff() {
         document.getElementById("rune5area").style.display = "block" :
         document.getElementById("rune5area").style.display = "none";
 
+    player.researches[124] > 0 ? //5x24 Research [AutoSac]
+        document.getElementById("antSacrificeButtons").style.display = "block" :
+        document.getElementById("antSacrificeButtons").style.display = "none";
+
     player.researches[130] > 0 ? //6x5 Research [Talisman Auto Fortify]
         document.getElementById("toggleautofortify").style.display = "block" :
         document.getElementById("toggleautofortify").style.display = "none";


### PR DESCRIPTION
PR #245 sneakily removed some lines and confused early players they could autosac without buying r5x24 first because the buttons were already displayed ;)