### PR TITLE
Fix Ant Autosac & C15 quark reward

### DIFF
--- a/Javascript/statistic.js
+++ b/Javascript/statistic.js
@@ -206,7 +206,7 @@ function c15RewardUpdate(){
     }
     if(e >= exponentRequirements[23]){
         //Quark Gain [100b]
-        challenge15Rewards[keys[23]] = 1 + 1/100 * Math.log(e/1e11) / Math.log(2)
+        challenge15Rewards[keys[23]] = 1 + 1/100 * Math.log(e/5e10) / Math.log(2)
     }
 
 

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -257,6 +257,14 @@ function revealStuff() {
         document.getElementById("talisman7area").style.display = "block" :
         document.getElementById("talisman7area").style.display = "none";
 
+    player.researches[124] > 0 ?
+        document.getElementById("toggleAutoSacrificeAnt").style.display = "block" :
+        document.getElementById("toggleAutoSacrificeAnt").style.display = "none";
+        document.getElementById("autoSacrificeAntMode").style.display = "block" :
+        document.getElementById("autoSacrificeAntMode").style.display = "none";
+        document.getElementById("autoAntSacrifice").style.display = "block" :
+        document.getElementById("autoAntSacrifice").style.display = "none";
+    
     player.cubeUpgrades[8] > 0 ?
         document.getElementById('particleAutoUpgrade').style.display = "block" :
         document.getElementById('particleAutoUpgrade').style.display = "none";

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -257,11 +257,13 @@ function revealStuff() {
         document.getElementById("talisman7area").style.display = "block" :
         document.getElementById("talisman7area").style.display = "none";
 
-    player.researches[124] > 0 ?
+    player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]
         document.getElementById("toggleAutoSacrificeAnt").style.display = "block" :
-        document.getElementById("toggleAutoSacrificeAnt").style.display = "none":
+        document.getElementById("toggleAutoSacrificeAnt").style.display = "none";
+    player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]    
         document.getElementById("autoSacrificeAntMode").style.display = "block" :
-        document.getElementById("autoSacrificeAntMode").style.display = "none":
+        document.getElementById("autoSacrificeAntMode").style.display = "none";
+    player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]    
         document.getElementById("autoAntSacrifice").style.display = "block" :
         document.getElementById("autoAntSacrifice").style.display = "none";
     

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -259,9 +259,9 @@ function revealStuff() {
 
     player.researches[124] > 0 ?
         document.getElementById("toggleAutoSacrificeAnt").style.display = "block" :
-        document.getElementById("toggleAutoSacrificeAnt").style.display = "none";
+        document.getElementById("toggleAutoSacrificeAnt").style.display = "none":
         document.getElementById("autoSacrificeAntMode").style.display = "block" :
-        document.getElementById("autoSacrificeAntMode").style.display = "none";
+        document.getElementById("autoSacrificeAntMode").style.display = "none":
         document.getElementById("autoAntSacrifice").style.display = "block" :
         document.getElementById("autoAntSacrifice").style.display = "none";
     

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -267,8 +267,8 @@ function revealStuff() {
         document.getElementById("autoAntSacrifice").style.display = "block" :
         document.getElementById("autoAntSacrifice").style.display = "none";
      player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]    
-        document.getElementById(" autoAntSacrificeAmount").style.display = "block" :
-        document.getElementById(" autoAntSacrificeAmount").style.display = "none";
+        document.getElementById("autoAntSacrificeAmount").style.display = "block" :
+        document.getElementById("autoAntSacrificeAmount").style.display = "none";
     
     player.cubeUpgrades[8] > 0 ?
         document.getElementById('particleAutoUpgrade').style.display = "block" :

--- a/Javascript/updatehtml.js
+++ b/Javascript/updatehtml.js
@@ -266,6 +266,9 @@ function revealStuff() {
     player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]    
         document.getElementById("autoAntSacrifice").style.display = "block" :
         document.getElementById("autoAntSacrifice").style.display = "none";
+     player.researches[124] > 0 ? // 5x24 Reasearch [Ant AutoSac]    
+        document.getElementById(" autoAntSacrificeAmount").style.display = "block" :
+        document.getElementById(" autoAntSacrificeAmount").style.display = "none";
     
     player.cubeUpgrades[8] > 0 ?
         document.getElementById('particleAutoUpgrade').style.display = "block" :


### PR DESCRIPTION
This solves two things

A while ago autosac displays before the function actually is able to run (pre research r5x24).

c15 reward for 100b (quarks) starts at 0 instead of 1%.