### PR TITLE
fix crystal upgrade description overlap

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -1814,8 +1814,8 @@ margin-left: -13px
 	top: 280px;
 	padding: 0;
 	left: 50%;
-	margin-left: -375px;
-	width: 750px;
+	margin-left: -400px;
+	width: 800px;
 	height: 100px;
 }
 #crystalupgradeslevel {


### PR DESCRIPTION
Widen the container for the crystal upgrade description to prevent overlapping

Before:
 
<img width="747" alt="Screen Shot 2021-06-03 at 1 22 12 PM" src="https://user-images.githubusercontent.com/6458318/120739757-9141cd00-c4b7-11eb-9143-a52fd36465d5.png">

After:

<img width="778" alt="Screen Shot 2021-06-03 at 1 22 34 PM" src="https://user-images.githubusercontent.com/6458318/120739786-9dc62580-c4b7-11eb-963c-61c8b3405195.png">

