### PR TITLE
Rescue savegame from broken browsers

### DIFF
--- a/savegame-rescue.html
+++ b/savegame-rescue.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <link rel="icon" href="favicon.ico" type="image/x-icon" sizes="16x16">
+    <title>Synergism v2.1.2</title>
+</head>
+<main>
+    <link rel="stylesheet" href="Synergism.css">
+
+    <div id="savegame" style="width:100px;">
+        Savegame not loaded
+    </div>
+
+    <script type='text/javascript'>
+        window.addEventListener('load', function () {
+            const save = localStorage.getItem("Synergysave2");
+            if (save != null) {
+                document.getElementById("savegame").textContent = save;
+            }
+        });
+    </script>
+</main>
+</html>


### PR DESCRIPTION
Savegame export is still broken in some browsers. It is not possible to update to the new version.
This pullrequest adds bulletproof export method for such cases.